### PR TITLE
fix: handle differing source and result sizes in updateCanvas

### DIFF
--- a/src/core/canvas.ts
+++ b/src/core/canvas.ts
@@ -43,8 +43,8 @@ export function updateCanvas(
 		coordinates.top + offsetY,
 		coordinates.width,
 		coordinates.height,
-		offsetX,
-		offsetY,
+		offsetX * (canvas.width / coordinates.width),
+		offsetY * (canvas.height / coordinates.height),
 		canvas.width,
 		canvas.height,
 	);


### PR DESCRIPTION
`updateCanvas` has a bug which only really comes to light if the size of the canvas and the size of the original image differ drastically and the image offset is positive. The `dx` and `dy` are not adjusted for the size difference.

Here is a visual representation:
<img width="460" alt="Frame 22 (1)" src="https://github.com/advanced-cropper/vue-advanced-cropper/assets/12705416/90ec37a9-28e2-49d9-bd7f-340c1a2f2da6">
_Since the output (100px) is half the size of the input (200px) the `dx` and `dy` have to be halfed._

---

_The same issue seems to exist in the master branch. I'll gladly also create a PR for the master branch, once this is merged :)_